### PR TITLE
Update to Aya v0.4

### DIFF
--- a/main.aya
+++ b/main.aya
@@ -4,6 +4,7 @@
 
 
 import ::canvas
+import ::time
 import "utils.fluid_logic"
 "utils.interactive_ui" importlib.import
 "config" importlib.import config .# execute config to load it
@@ -79,6 +80,8 @@ grid_size_y 2+ 2/ :center;
 
 M$ :prev_time;
 [0 0] :prev_cursor_position;
+0:avg_time;
+50 time.rate!:limiter;
 {
 	M$ :cur_time;
 	cur_time prev_time - :delta_ms;
@@ -141,12 +144,14 @@ M$ :prev_time;
 	
 	print_frame_delta {
 		M$ :end;
-		"frame delta: "end start - + " ms"+ :P
+		end start - :delta;
+		avg_time 0.95 * delta 0.05 * + :avg_time;
+		"frame delta: $delta ms (avg $avg_time)":P
 	}?
 	
 	_canvas.show
 
 	cur_time :prev_time;
-	17 :Z	
+	limiter.sleep
 	_canvas.isopen
 }W

--- a/main.aya
+++ b/main.aya
@@ -4,8 +4,8 @@
 
 import ::canvas
 import ::matrix
-"utils\\fluid_logic" importlib.import
-"utils\\interactive_ui" importlib.import
+import "utils.fluid_logic"
+"utils.interactive_ui" importlib.import
 "config" importlib.import config .# execute config to load it
 "ui_setup" importlib.import ui_setup
 

--- a/main.aya
+++ b/main.aya
@@ -2,10 +2,8 @@
 	This main is a mess, I'm sorry.
 .}
 
-bp
 
 import ::canvas
-import ::matrix
 import "utils.fluid_logic"
 "utils.interactive_ui" importlib.import
 "config" importlib.import config .# execute config to load it
@@ -14,8 +12,8 @@ import "utils.fluid_logic"
 grid_size_x 2+ grid_size_y 2+ solver_iterations fluid_logic! :fluid;
 
 grid_size_y 2+ 2/ :center;
-[grid_size_y 2+,][grid_size_x 2+,]{y x, 10 x5-$* y center -$*0.4* + - 0.< 20 *}:* matrix! :velocity_gain_x;
-[grid_size_y 2+,][grid_size_x 2+,]{y x, 0}:* matrix! :velocity_gain_y;
+[grid_size_y 2+,][grid_size_x 2+,]{y x, 10 x5-$* y center -$*0.4* + - 0.< 20 *}:* :velocity_gain_x;
+[grid_size_y 2+,][grid_size_x 2+,]{y x, 0}:* :velocity_gain_y;
 
 20: cur_vx_max;
 20: cur_vy_max;
@@ -102,8 +100,8 @@ M$ :prev_time;
 				move_event.x prev_x - :dx;
 				move_event.y prev_y - :dy;
 				
-				dx 0 = ! { dx move_dt * drag_intensity * velocity_gain_x.rows yo I :& xo I @ + \ xo D; } ?
-				dy 0 = ! { dy move_dt * drag_intensity * velocity_gain_y.rows yo I :& xo I @ + \ xo D; } ?
+				dx 0 = ! { dx move_dt * drag_intensity * velocity_gain_x yo I :& xo I @ + \ xo D; } ?
+				dy 0 = ! { dy move_dt * drag_intensity * velocity_gain_y yo I :& xo I @ + \ xo D; } ?
 				drag_density_gain move_dt * densities yo I :& xo I @ + \ xo D;
 				
 				move_event.x :prev_x;
@@ -119,15 +117,15 @@ M$ :prev_time;
 	print_frame_delta {M$ :start;}?
 	
 	.# apply velocity gain
-	velocity_x matrix._new velocity_gain_x + .rows :velocity_x;
-	velocity_y matrix._new velocity_gain_y + .rows :velocity_y;
+	velocity_x velocity_gain_x + :velocity_x;
+	velocity_y velocity_gain_y + :velocity_y;
 	
 	.# damp gains
 	velocity_gain_x 0.8 * :velocity_gain_x;
 	velocity_gain_y 0.8 * :velocity_gain_y;
 	
 	.# disperse density
-	densities matrix._new 0.99 * .rows :densities;
+	densities 0.99 * :densities;
 	
 	.# handle velocity update
 	velocity_x velocity_y advection_rate projection_rate viscosity fluid.simulate_velocity :velocity_y; :velocity_x;
@@ -136,9 +134,9 @@ M$ :prev_time;
 	densities velocity_x velocity_y diffusion_rate advection_rate fluid.simulate_density :densities;
 	
 	.# draw canvas
-	densities matrix._new:1\.pad.rows
-	velocity_x matrix._new:1\.pad.rows
-	velocity_y matrix._new:1\.pad.rows
+	densities :1\.pad
+	velocity_x :1\.pad
+	velocity_y :1\.pad
 	render_functions render_mode I ~
 	
 	print_frame_delta {

--- a/main.aya
+++ b/main.aya
@@ -2,6 +2,8 @@
 	This main is a mess, I'm sorry.
 .}
 
+bp
+
 import ::canvas
 import ::matrix
 import "utils.fluid_logic"
@@ -26,7 +28,7 @@ grid_size_y 2+ 2/ :center;
 {densities velocity_x velocity_y,
 	densities    E :size_y;
 	densities.[0]E :size_x;
-	densities :#{{.|\.|.<}/}{.<}/ :d_max;
+	densities :#{{.|\.|.<}%}{.<}% :d_max;
 	
 	cur_d_max d_max move_towards 0.5.< :cur_d_max;
 	
@@ -40,9 +42,9 @@ grid_size_y 2+ 2/ :center;
 {densities velocity_x velocity_y,
 	densities    E :size_y;
 	densities.[0]E :size_x;
-	velocity_x :#{{.|\.|.<}/}{.<}/ :vx_max;
-	velocity_y :#{{.|\.|.<}/}{.<}/ :vy_max;
-	densities :#{{.|\.|.<}/}{.<}/ :d_max;
+	velocity_x :#{{.|\.|.<}%}{.<}% :vx_max;
+	velocity_y :#{{.|\.|.<}%}{.<}% :vy_max;
+	densities :#{{.|\.|.<}%}{.<}% :d_max;
 	
 	cur_vx_max vx_max move_towards 0.5.< :cur_vx_max;
 	cur_vy_max vy_max move_towards 0.5.< :cur_vy_max;
@@ -58,8 +60,8 @@ grid_size_y 2+ 2/ :center;
 {densities velocity_x velocity_y,
 	densities    E :size_y;
 	densities.[0]E :size_x;
-	velocity_x :#{{.|\.|.<}/}{.<}/ :vx_max;
-	velocity_y :#{{.|\.|.<}/}{.<}/ :vy_max;
+	velocity_x :#{{.|\.|.<}%}{.<}% :vx_max;
+	velocity_y :#{{.|\.|.<}%}{.<}% :vy_max;
 	
 	cur_vx_max vx_max move_towards 0.5.< :cur_vx_max;
 	cur_vy_max vy_max move_towards 0.5.< :cur_vy_max;

--- a/ui_setup.aya
+++ b/ui_setup.aya
@@ -1,7 +1,7 @@
 {
 
 import ::canvas
-"utils\\interactive_ui" importlib.import
+"utils/interactive_ui" importlib.import
 
 250 :ui_width;
 

--- a/utils/fluid_logic.aya
+++ b/utils/fluid_logic.aya
@@ -1,4 +1,3 @@
-import ::matrix
 export ::fluid_logic
 
 class fluid_logic
@@ -9,24 +8,24 @@ class fluid_logic
 	
 	.# a boundary_func for fluid_logic::diffuse that duplicates the edge values outwards
 	def fluid_logic::boundary_duplicate {scalar_mat fluid_logic,
-		scalar_mat.rows :&0I \ :&:&E1-I \ .B.V
-					 .T :&0I \ :&:&E1-I \ .B.V .T matrix._new
+		scalar_mat :&0I \ :&:&E1-I \ .B.V
+					 .T :&0I \ :&:&E1-I \ .B.V .T
 	}
 	
 	.# a boundary_func for fluid_logic::diffuse
 	.#   it duplicates the left/right edge values
 	.#   and mirrors the top/bottom edge values
 	def fluid_logic::boundary_mirror_y {scalar_mat fluid_logic,
-		scalar_mat.rows :&0I:1* \ :&:&E1-I:1* \ .B.V
-					 .T :&0I    \ :&:&E1-I    \ .B.V .T matrix._new
+		scalar_mat :&0I:1* \ :&:&E1-I:1* \ .B.V
+					 .T :&0I    \ :&:&E1-I    \ .B.V .T
 	}
 	
 	.# a boundary_func for fluid_logic::diffuse
 	.#   it mirrors the left/right edge values
 	.#   and duplicates the top/bottom edge values
 	def fluid_logic::boundary_mirror_x {scalar_mat fluid_logic,
-		scalar_mat.rows :&0I    \ :&:&E1-I    \ .B.V
-					 .T :&0I:1* \ :&:&E1-I:1* \ .B.V .T matrix._new
+		scalar_mat :&0I    \ :&:&E1-I    \ .B.V
+					 .T :&0I:1* \ :&:&E1-I:1* \ .B.V .T
 	}
 
 
@@ -69,7 +68,7 @@ class fluid_logic
 	.# compute a new grid of scalars that are diffused (each cell approaches the average of its neighbors)
 	.# boundary_func must be a function mapping from the inner matrix to the full matrix, e.g. '{mat, mat 1\.pad}'
 	def fluid_logic::diffuse {scalar_grid::list rate::num boundary_func::block self,
-		scalar_grid matrix._new :old_mat $ :new_mat;;
+		scalar_grid :old_mat $ :new_mat;;
 		
 		self.solver_iterations .R :# {iteration,
 			{new_mat.rotate_rows} :rr;
@@ -82,7 +81,7 @@ class fluid_logic
 			4 rate * 1 + /
 			:1\.pad boundary_func :new_mat;
 		};
-		new_mat.rows
+		new_mat
 	}
 	
 	.# given a grid of scalars, compute a new grid of scalars that are carried along by the given velocities
@@ -93,17 +92,17 @@ class fluid_logic
 		self.y_dim 	:y_dim;
 		
 		[ .# for x,y gather scalars[ [x y] [x y+1] [x+1 y] [x+1 y+1] ]
-			scalar_grid matrix._new
+			scalar_grid
 			:& :1 \ .rotate_rows
 			:& :1 \ .rotate_cols
 			:& 1 \ .rotate_rows \
-		]:#{.rows}.T:#{.T} :scalars_xoyo_xoyi_xiyo_xiyi;
+		] .T:#{.T} :scalars_xoyo_xoyi_xiyo_xiyi;
 		
 		[
 			[x_dim 2-R {:&} y_dim 3- %] 		.# for every non-boundary grid cell, store x coordinate
 			[y_dim 2-R {:&} x_dim 3- %].T 		.# non-boundary y coordinates
-			:1 velocity_x matrix._new.pad .rows	.# non-boundary x velocities
-			:1 velocity_y matrix._new.pad .rows	.# non-boundary y velocities
+			:1 velocity_x .pad	.# non-boundary x velocities
+			:1 velocity_y .pad	.# non-boundary y velocities
 		].T:#{.T:#{~ :vy; :vx; :y; :x; .# for every non-boundary cell as [x y vx vy]
 			x vx advection_rate * -   0.5.<   x_dim 1.5-.> :xs .\ :xo;
 			y vy advection_rate * -   0.5.<   y_dim 1.5-.> :ys .\ :yo;
@@ -116,21 +115,21 @@ class fluid_logic
 			\ dxi dyo * * +
 			\ dxo dyi * * +
 			\ dxo dyo * * +
-		}}matrix._new boundary_func .rows
+		}}boundary_func
 	}
 	
 	.# ensure that velocities are mass conserving by removing divergence
 	.# returns new {velocity_x velocity_y}
 	def fluid_logic::project {velocity_x::list velocity_y::list projection_rate::num self,
-		velocity_x matrix._new :velocity_x;
-		velocity_y matrix._new :velocity_y;
+		velocity_x :velocity_x;
+		velocity_y :velocity_y;
 		
 		:1 velocity_x.rotate_cols   1 velocity_x.rotate_cols  -
 		:1 velocity_y.rotate_rows   1 velocity_y.rotate_rows  - +
 		:0.5 projection_rate * *
 		:1\.pad fluid_logic.boundary_duplicate :divergence;
 		
-		[self.y_dim self.x_dim] matrix.zeros :poisson;
+		[self.y_dim self.x_dim] 0\L :poisson;
 		
 		self.solver_iterations .R :# {iteration,
 			{poisson.rotate_rows} :rr;
@@ -146,5 +145,5 @@ class fluid_logic
 		velocity_y :1 poisson.rotate_rows 1 poisson.rotate_rows - 0.5 projection_rate / * -
 		:1\.pad fluid_logic.boundary_mirror_y :velocity_y;
 		
-		velocity_x.rows velocity_y.rows
+		velocity_x velocity_y
 	}


### PR DESCRIPTION
A few updates to make EsoWave work with Aya v0.4 (https://github.com/aya-lang/aya/releases/tag/v0.4.0-rc1)

The code is largely unchanged with a few exceptions:
  -  `matrix` operations are replaced with built-in vectorization from 0.4 (which was optimized internally in 0.4 as well).  The simulation runs about 2.5x faster on my machine.
  - changed imports from `\\` notation to `.` notation which should make them cross-platform. Let me know if you have any issues with it though!
  - `:Z` was replaced with `time.rate` which should give a more consistent FPS